### PR TITLE
Use the same config file as Tox

### DIFF
--- a/src/tox_travis/toxenv.py
+++ b/src/tox_travis/toxenv.py
@@ -4,7 +4,6 @@ from itertools import product
 import os
 import sys
 import re
-import py
 import tox.config
 from tox.config import _split_env as split_env
 from .utils import TRAVIS_FACTORS, parse_dict
@@ -15,7 +14,7 @@ def default_toxenv(config):
     if 'TOXENV' in os.environ or config.option.env:
         return  # Skip any processing if already set
 
-    ini = py.iniconfig.IniConfig('tox.ini')
+    ini = config._cfg
 
     # Find the envs that tox knows about
     declared_envs = get_declared_envs(ini)
@@ -235,8 +234,7 @@ def env_matches(declared, desired):
 
 def override_ignore_outcome(config):
     """Override ignore_outcome if unignore_outcomes is set to True."""
-    tox_config = py.iniconfig.IniConfig('tox.ini')
-    travis_reader = tox.config.SectionReader("travis", tox_config)
+    travis_reader = tox.config.SectionReader("travis", config._cfg)
     if travis_reader.getbool('unignore_outcomes', False):
         for envconfig in config.envconfigs.values():
             envconfig.ignore_outcome = False

--- a/tests/test_after.py
+++ b/tests/test_after.py
@@ -13,7 +13,7 @@ class TestAfter:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PULL_REQUEST', '1')
 
-        travis_after(mocker.Mock())
+        travis_after(mocker.Mock(), mocker.Mock())
 
         out, err = capsys.readouterr()
         assert out == ''
@@ -25,7 +25,7 @@ class TestAfter:
                      return_value=True)
         monkeypatch.setenv('TRAVIS', 'true')
         with pytest.raises(SystemExit) as excinfo:
-            travis_after(mocker.Mock())
+            travis_after(mocker.Mock(), mocker.Mock())
 
         assert excinfo.value.code == 32
         out, err = capsys.readouterr()
@@ -38,7 +38,7 @@ class TestAfter:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('GITHUB_TOKEN', 'spamandeggs')
         with pytest.raises(SystemExit) as excinfo:
-            travis_after(mocker.Mock())
+            travis_after(mocker.Mock(), mocker.Mock())
 
         assert excinfo.value.code == 34
         out, err = capsys.readouterr()
@@ -52,7 +52,7 @@ class TestAfter:
         monkeypatch.setenv('GITHUB_TOKEN', 'spamandeggs')
         monkeypatch.setenv('TRAVIS_BUILD_ID', '1234')
         with pytest.raises(SystemExit) as excinfo:
-            travis_after(mocker.Mock())
+            travis_after(mocker.Mock(), mocker.Mock())
 
         assert excinfo.value.code == 34
         out, err = capsys.readouterr()
@@ -69,7 +69,7 @@ class TestAfter:
         # TRAVIS_API_URL is set to a reasonable default
         monkeypatch.setenv('TRAVIS_API_URL', '')
         with pytest.raises(SystemExit) as excinfo:
-            travis_after(mocker.Mock())
+            travis_after(mocker.Mock(), mocker.Mock())
 
         assert excinfo.value.code == 34
         out, err = capsys.readouterr()
@@ -86,7 +86,7 @@ class TestAfter:
         # TRAVIS_POLLING_INTERVAL is set to a reasonable default
         monkeypatch.setenv('TRAVIS_POLLING_INTERVAL', 'xbe')
         with pytest.raises(SystemExit) as excinfo:
-            travis_after(mocker.Mock())
+            travis_after(mocker.Mock(), mocker.Mock())
 
         assert excinfo.value.code == 33
         out, err = capsys.readouterr()
@@ -186,7 +186,7 @@ class TestAfter:
         get_json.responses = iter(responses)
 
         mocker.patch('tox_travis.after.get_json', side_effect=get_json)
-        travis_after(mocker.Mock())
+        travis_after(mocker.Mock(), mocker.Mock())
         out, err = capsys.readouterr()
         assert 'All required jobs were successful.' in out
 
@@ -289,7 +289,7 @@ class TestAfter:
         mocker.patch('tox_travis.after.get_json', side_effect=get_json)
 
         with pytest.raises(SystemExit) as excinfo:
-            travis_after(mocker.Mock())
+            travis_after(mocker.Mock(), mocker.Mock())
 
         assert excinfo.value.code == 35
         out, err = capsys.readouterr()


### PR DESCRIPTION
If successful, this fixes #57.

No new tests have been added, though some have been modified to adjust to the new call signature.