### PR TITLE
Move toxenv to tox_configure hook

### DIFF
--- a/docs/after.rst
+++ b/docs/after.rst
@@ -101,11 +101,9 @@ that you are shipping a working release.
 The accepted configuration keys
 in the ``[travis:after]`` section are:
 
-* ``toxenv``. Match with the running toxenvs,
-  based on the ``TOXENV`` environment variable,
-  which is set automatically by Tox-Travis.
+* ``toxenv``. Match with the running toxenvs.
   Expansion is allowed, and if set *all* environments listed
-  must be present in the ``TOXENV`` environment variable.
+  must be run in the current Tox run.
 * ``travis``. Match with known Travis factors,
   as is done in the ``[travis]`` section.
   For instance, specifying that we should wait

--- a/src/tox_travis/hooks.py
+++ b/src/tox_travis/hooks.py
@@ -17,7 +17,6 @@ def tox_addoption(parser):
         help='Exit successfully after all Travis jobs complete successfully.')
 
     if 'TRAVIS' in os.environ:
-        default_toxenv()
         pypy_version_monkeypatch()
 
 
@@ -27,4 +26,5 @@ def tox_configure(config):
     if 'TRAVIS' in os.environ:
         if config.option.travis_after:
             travis_after_monkeypatch()
+        default_toxenv(config)
         override_ignore_outcome(config)

--- a/tests/test_after.py
+++ b/tests/test_after.py
@@ -13,7 +13,7 @@ class TestAfter:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('TRAVIS_PULL_REQUEST', '1')
 
-        travis_after()
+        travis_after(mocker.Mock())
 
         out, err = capsys.readouterr()
         assert out == ''
@@ -25,7 +25,7 @@ class TestAfter:
                      return_value=True)
         monkeypatch.setenv('TRAVIS', 'true')
         with pytest.raises(SystemExit) as excinfo:
-            travis_after()
+            travis_after(mocker.Mock())
 
         assert excinfo.value.code == 32
         out, err = capsys.readouterr()
@@ -38,7 +38,7 @@ class TestAfter:
         monkeypatch.setenv('TRAVIS', 'true')
         monkeypatch.setenv('GITHUB_TOKEN', 'spamandeggs')
         with pytest.raises(SystemExit) as excinfo:
-            travis_after()
+            travis_after(mocker.Mock())
 
         assert excinfo.value.code == 34
         out, err = capsys.readouterr()
@@ -52,7 +52,7 @@ class TestAfter:
         monkeypatch.setenv('GITHUB_TOKEN', 'spamandeggs')
         monkeypatch.setenv('TRAVIS_BUILD_ID', '1234')
         with pytest.raises(SystemExit) as excinfo:
-            travis_after()
+            travis_after(mocker.Mock())
 
         assert excinfo.value.code == 34
         out, err = capsys.readouterr()
@@ -69,7 +69,7 @@ class TestAfter:
         # TRAVIS_API_URL is set to a reasonable default
         monkeypatch.setenv('TRAVIS_API_URL', '')
         with pytest.raises(SystemExit) as excinfo:
-            travis_after()
+            travis_after(mocker.Mock())
 
         assert excinfo.value.code == 34
         out, err = capsys.readouterr()
@@ -86,7 +86,7 @@ class TestAfter:
         # TRAVIS_POLLING_INTERVAL is set to a reasonable default
         monkeypatch.setenv('TRAVIS_POLLING_INTERVAL', 'xbe')
         with pytest.raises(SystemExit) as excinfo:
-            travis_after()
+            travis_after(mocker.Mock())
 
         assert excinfo.value.code == 33
         out, err = capsys.readouterr()
@@ -186,7 +186,7 @@ class TestAfter:
         get_json.responses = iter(responses)
 
         mocker.patch('tox_travis.after.get_json', side_effect=get_json)
-        travis_after()
+        travis_after(mocker.Mock())
         out, err = capsys.readouterr()
         assert 'All required jobs were successful.' in out
 
@@ -289,7 +289,7 @@ class TestAfter:
         mocker.patch('tox_travis.after.get_json', side_effect=get_json)
 
         with pytest.raises(SystemExit) as excinfo:
-            travis_after()
+            travis_after(mocker.Mock())
 
         assert excinfo.value.code == 35
         out, err = capsys.readouterr()

--- a/tests/test_toxenv.py
+++ b/tests/test_toxenv.py
@@ -416,7 +416,7 @@ class TestToxEnv:
         """Test ignore_outcome without setting obey_outcomes."""
         tox_ini = tox_ini_ignore_outcome
         with self.configure(
-            tmpdir, monkeypatch, tox_ini, travis_language='generic'
+            tmpdir, monkeypatch, tox_ini, travis_version='3.4'
         ):
             config = self.tox_config()
             assert config["testenv:py34"]["ignore_outcome"] == "True"
@@ -426,7 +426,7 @@ class TestToxEnv:
         """Test ignore_outcome setting unignore_outcomes = False."""
         tox_ini = tox_ini_ignore_outcome_unignore_outcomes
         with self.configure(
-            tmpdir, monkeypatch, tox_ini, travis_language='generic'
+            tmpdir, monkeypatch, tox_ini, travis_version='3.4'
         ):
             config = self.tox_config()
             assert config["testenv:py34"]["ignore_outcome"] == "False"
@@ -436,7 +436,7 @@ class TestToxEnv:
         """Test ignore_outcome setting unignore_outcomes = False (default)."""
         tox_ini = tox_ini_ignore_outcome_not_unignore_outcomes
         with self.configure(
-            tmpdir, monkeypatch, tox_ini, travis_language='generic'
+            tmpdir, monkeypatch, tox_ini, travis_version='3.4'
         ):
             config = self.tox_config()
             assert config["testenv:py34"]["ignore_outcome"] == "True"


### PR DESCRIPTION
The tox_configure hook is much better suited for the purpose of toxenv. This PR is some refactors to aid, and a move of the bulk of the project to being triggered via the tox_configure hook. This is based off of the idea of #61, so it also closes #71. Thanks @rpkilby!

The abandonment of `TOXENV` to communicate with Tox also means that this also fixes #44 as a side-effect.