### PR TITLE
Refactor after monkeypatch

### DIFF
--- a/src/tox_travis/after.py
+++ b/src/tox_travis/after.py
@@ -22,27 +22,13 @@ INCOMPLETE_TRAVIS_ENVIRONMENT = 34
 JOBS_FAILED = 35
 
 
-def travis_after_monkeypatch(ini, envlist):
-    """Monkeypatch the Tox session to wait for jobs to finish."""
-    import tox.session
-    real_subcommand_test = tox.session.Session.subcommand_test
-
-    def subcommand_test(self):
-        retcode = real_subcommand_test(self)
-        if retcode == 0:
-            # No need to run if the tests failed anyway
-            travis_after(envlist, ini)
-        return retcode
-    tox.session.Session.subcommand_test = subcommand_test
-
-
-def travis_after(envlist, ini):
+def travis_after(ini, envlist):
     """Wait for all jobs to finish, then exit successfully."""
     # after-all disabled for pull requests
     if os.environ.get('TRAVIS_PULL_REQUEST', 'false') != 'false':
         return
 
-    if not after_config_matches(envlist, ini):
+    if not after_config_matches(ini, envlist):
         return  # This is not the one that needs to wait
 
     github_token = os.environ.get('GITHUB_TOKEN')
@@ -76,7 +62,7 @@ def travis_after(envlist, ini):
     print('All required jobs were successful.')
 
 
-def after_config_matches(envlist, ini):
+def after_config_matches(ini, envlist):
     """Determine if this job should wait for the others."""
     section = ini.sections.get('travis:after', {})
 

--- a/src/tox_travis/hacks.py
+++ b/src/tox_travis/hacks.py
@@ -16,3 +16,16 @@ def pypy_version_monkeypatch():
     version = os.environ.get('TRAVIS_PYTHON_VERSION')
     if version and default_factors and version.startswith('pypy3.3-'):
         default_factors['pypy3'] = 'python'
+
+
+def subcommand_test_monkeypatch(post):
+    """Monkeypatch Tox session to call a hook when commands finish."""
+    import tox.session
+    real_subcommand_test = tox.session.Session.subcommand_test
+
+    def subcommand_test(self):
+        retcode = real_subcommand_test(self)
+        post(self.config)
+        return retcode
+
+    tox.session.Session.subcommand_test = subcommand_test

--- a/src/tox_travis/hooks.py
+++ b/src/tox_travis/hooks.py
@@ -8,8 +8,11 @@ from .envlist import (
     autogen_envconfigs,
     override_ignore_outcome,
 )
-from .hacks import pypy_version_monkeypatch
-from .after import travis_after_monkeypatch
+from .hacks import (
+    pypy_version_monkeypatch,
+    subcommand_test_monkeypatch,
+)
+from .after import travis_after
 
 
 @tox.hookimpl
@@ -21,6 +24,7 @@ def tox_addoption(parser):
 
     if 'TRAVIS' in os.environ:
         pypy_version_monkeypatch()
+        subcommand_test_monkeypatch(tox_subcommand_test_post)
 
 
 @tox.hookimpl
@@ -47,6 +51,8 @@ def tox_configure(config):
         for envconfig in config.envconfigs.values():
             envconfig.ignore_outcome = False
 
-    # after
+
+def tox_subcommand_test_post(config):
+    """Wait for this job if the configuration matches."""
     if config.option.travis_after:
-        travis_after_monkeypatch(ini, config.envlist)
+        travis_after(config._cfg, config.envlist)

--- a/tests/test_after.py
+++ b/tests/test_after.py
@@ -306,7 +306,7 @@ class TestAfter:
             'envlist = py36\n'
         )
         ini = py.iniconfig.IniConfig('', data=inistr)
-        assert not after_config_matches(['py36'], ini)
+        assert not after_config_matches(ini, ['py36'])
 
     def test_after_config_matches_toxenv_match(self, capsys):
         """Test that it works using the legacy toxenv setting.
@@ -321,7 +321,7 @@ class TestAfter:
             'toxenv = py36\n'
         )
         ini = py.iniconfig.IniConfig('', data=inistr)
-        assert after_config_matches(['py36'], ini)
+        assert after_config_matches(ini, ['py36'])
         out, err = capsys.readouterr()
         msg = 'The "toxenv" key of the [travis:after] section is deprecated'
         assert msg in err
@@ -339,7 +339,7 @@ class TestAfter:
             'toxenv = py36\n'
         )
         ini = py.iniconfig.IniConfig('', data=inistr)
-        assert not after_config_matches(['py35'], ini)
+        assert not after_config_matches(ini, ['py35'])
         out, err = capsys.readouterr()
         msg = 'The "toxenv" key of the [travis:after] section is deprecated'
         assert msg in err
@@ -354,7 +354,7 @@ class TestAfter:
             'envlist = py36\n'
         )
         ini = py.iniconfig.IniConfig('', data=inistr)
-        assert after_config_matches(['py36'], ini)
+        assert after_config_matches(ini, ['py36'])
 
     def test_after_config_matches_envlist_nomatch(self):
         """Test that it doesn't work."""
@@ -366,7 +366,7 @@ class TestAfter:
             'envlist = py36\n'
         )
         ini = py.iniconfig.IniConfig('', data=inistr)
-        assert not after_config_matches(['py35'], ini)
+        assert not after_config_matches(ini, ['py35'])
 
     def test_after_config_matches_env_match(self, monkeypatch):
         """Test that it works."""
@@ -383,7 +383,7 @@ class TestAfter:
             '    DJANGO: 1.11\n'
         )
         ini = py.iniconfig.IniConfig('', data=inistr)
-        assert after_config_matches(['py36'], ini)
+        assert after_config_matches(ini, ['py36'])
 
     def test_after_config_matches_env_nomatch(self, monkeypatch):
         """Test that it doesn't work."""
@@ -400,4 +400,4 @@ class TestAfter:
             '    DJANGO: 1.11\n'
         )
         ini = py.iniconfig.IniConfig('', data=inistr)
-        assert not after_config_matches(['py35'], ini)
+        assert not after_config_matches(ini, ['py35'])

--- a/tests/test_after.py
+++ b/tests/test_after.py
@@ -23,6 +23,13 @@ class TestAfter:
         assert out == ''
         assert err == ''
 
+    def test_not_after_config_matches(self, mocker, monkeypatch, capsys):
+        """Return silently when no config matches."""
+        mocker.patch('tox_travis.after.after_config_matches',
+                     return_value=False)
+        monkeypatch.setenv('TRAVIS', 'true')
+        travis_after(mocker.Mock(), mocker.Mock())
+
     def test_no_github_token(self, mocker, monkeypatch, capsys):
         """Raise with the right message when no github token."""
         mocker.patch('tox_travis.after.after_config_matches',

--- a/tests/test_hacks.py
+++ b/tests/test_hacks.py
@@ -1,0 +1,25 @@
+"""Tests of the --travis-after flag."""
+from tox_travis.hacks import subcommand_test_monkeypatch
+
+
+class TestSessionSubcommandTest:
+    """Test the overridden post hook for subcommand_test."""
+
+    def test_subcommand_test_post_hook(self, mocker):
+        """It should return the same retcode, but run the hook."""
+        subcommand_test = mocker.patch('tox.session.Session.subcommand_test',
+                                       return_value=42)
+        tox_subcommand_test_post = mocker.Mock()
+        subcommand_test_monkeypatch(tox_subcommand_test_post)
+
+        import tox.session
+        session = mocker.Mock()
+
+        real_subcommand_test = tox.session.Session.subcommand_test
+        # Python 2 compat
+        real_subcommand_test = getattr(
+            real_subcommand_test, '__func__', real_subcommand_test)
+
+        assert real_subcommand_test(session) == 42
+        subcommand_test.assert_called_once_with(session)
+        tox_subcommand_test_post.assert_called_once_with(session.config)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,17 @@
+from tox_travis.hooks import tox_subcommand_test_post
+
+
+class TestToxSubcommandTestPost:
+    def test_tox_subcommand_test_post_enabled(self, mocker):
+        travis_after = mocker.patch('tox_travis.hooks.travis_after')
+        config = mocker.Mock()
+        config.option.travis_after = True
+        tox_subcommand_test_post(config)
+        travis_after.assert_called_once_with(config._cfg, config.envlist)
+
+    def test_tox_subcommand_test_post_not_enabled(self, mocker):
+        travis_after = mocker.patch('tox_travis.hooks.travis_after')
+        config = mocker.Mock()
+        config.option.travis_after = False
+        tox_subcommand_test_post(config)
+        assert not travis_after.called


### PR DESCRIPTION
Refactor the monkeypatching required by after to allow it to look more like a hook. This will hopefully make the implementation a bit easier to follow and test, since the hook is unconditionally monkeypatched in.