### PR TITLE
Draft 0.9 release notes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,6 @@ python:
  - "pypy3.3-5.5-alpha"
  - "3.7-dev"
 
-before_install:
- # Show the current setuptools version
- - python -c "import setuptools; print(setuptools.__version__)"
 install:
  - pip install wheel codecov coverage
  - python setup.py bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ branches:
 matrix:
   fast_finish: true
   include:
-  - python: 3.5
+  - python: 3.6
     env: TOXENV=docs
-  - python: 3.5
+  - python: 3.6
     env: TOXENV=desc
 
 deploy:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,19 @@
+0.9 (TBD)
++++++++++
+
+* Allow PyPy3 support to work with PyPy3 5.5 (#66).
+  - thanks to @kirbyfan64 for the pull request.
+* Move toxenv to tox_configure hook (#78).
+  - thanks to @rpkilby for the pull request demonstrating the idea.
+* Respect Tox config file CLI option (#59).
+  - thanks to @giginet for the bug report.
+* Move the project into the ``tox-dev`` GitHub organization.
+  - thanks to @obestwalter for bringing it up,
+  and @rpkilby for helping fix references to the old location.
+* Various refactors and test improvements.
+  - thanks to @jdufresne for several pull requests
+  and @rpkilby for many reviews.
+
 0.8 (2017-01-11)
 ++++++++++++++++
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,10 @@
 * Various refactors and test improvements.
   - thanks to @jdufresne for several pull requests
   and @rpkilby for many reviews.
+* Only deploy the universal wheel to PyPI.
+  Due to a deployment bug, a version-specific egg was released,
+  along with the intended sdist and wheel.
+  The sdist has also been abandoned for release.
 
 0.8 (2017-01-11)
 ++++++++++++++++


### PR DESCRIPTION
Ideally I want to fix the deployment so that we no longer ship an egg. Perhaps even not ship any more sdists either, so that we can drop the sdist tests from the build as well.