### PR TITLE
Deploy only a wheel to PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,6 @@ __pycache__/
 *.egg-info/
 /.tox/
 /.cache/
-/build/
-/dist/
 docs/_build/
 /.coverage*
 /htmlcov/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,9 @@ before_install:
  - python -c "import setuptools; print(setuptools.__version__)"
 install:
  - pip install wheel codecov coverage
- - python setup.py install bdist_wheel
+ - python setup.py bdist_wheel
  - pip install ./dist/tox_travis-*.whl
 script:
- - tox
  - tox --installpkg ./dist/tox_travis-*.whl --travis-after
 after_success: coverage combine && codecov
 
@@ -47,4 +46,4 @@ deploy:
     tags: true
     python: 3.6
     condition: $TOXENV != docs && $TOXENV != desc
-  distributions: sdist bdist_wheel
+  distributions: bdist_wheel


### PR DESCRIPTION
The only gotcha I can think of for this is if somehow it's running on a really old version of pip. But I think that should be a non-issue on Travis. If it is an issue, I would expect us to have already seen it, since we are installing wheels in every job anyway.