### PR TITLE
Deprecate After All

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,21 +18,27 @@ install:
  - pip install wheel codecov coverage
  - python setup.py bdist_wheel
  - pip install ./dist/tox_travis-*.whl
-script:
- - tox --installpkg ./dist/tox_travis-*.whl --travis-after
+script: tox --installpkg ./dist/tox_travis-*.whl
 after_success: coverage combine && codecov
 
-branches:
-  only:
-    - master
-    - /^\d+(\.\d+)*$/
-matrix:
+if: tag IS present OR branch = master
+jobs:
   fast_finish: true
   include:
   - python: 3.6
     env: TOXENV=docs
   - python: 3.6
     env: TOXENV=desc
+  - stage: deploy
+    python: 3.6
+    env: TRAVIS_STAGE=deploy
+    install: true
+    script: true
+    after_success: true
+
+stages:
+  - name: deploy
+    if: tag IS present
 
 deploy:
   provider: pypi
@@ -41,6 +47,5 @@ deploy:
     secure: KjQrEjwmfP+jqdHNQ6bJoNjOJHHz0kirrSORat2uJTulXaUs/nuDcZqTu7gxMFaM92z3eJZzTZmxO71cDhJiBt+FQhEtL/q8wd7Fv5d5v5EIlLFNqdEyCaTthSgXQa/HJTtbzjdFIEN8qCofHu+zEWMnb1ZHgUcK7hZHMCrHcVF4kD+k1myNro+1Pp/sGIUMUOkqocz+8OI2FuEQh0txXl0MLf2UEk53EK2noD4D/fm/YDDYJbAWlNPBbCBaU/ZGfzuFivh00bx9lAg7UB6t/A3iIasRUiAJbHdxvrxxGFAeOV/t09TcTtEcwBRyPe8JzSuReCROccyFB2TLOzfkt9h7TkdC2CWrMmXpI6UogTct++r3kavdsJuAZMbSy1jrnxkxtB1CW7DOly4v4JuyewpET7CnTjkhd9zIowESwJFjxwmns63AS2okQdPTCqsbbNp53Jk5fpf6qXwMFdaHT1kU1MpwoQPT0HnwLz3xybvjgfgu3t4KfEBvc0DCp89VMjCM9xkKTlziZkwOhXqaNhu+cVqo1/eUY/HDT/7V7xiL/U6U11UOrqtxkdDofoIl4NuiT7uoVaVctm/Y4kBEkJRZCwcjRsZJ0c06SvMvxhMDBUEM5IiXS6tH6Zp08MDYlclpKFGKdzOrxP2X0rVFIZ99KLyhfRNZuZcu92tDpP8=
   on:
     tags: true
-    python: 3.6
-    condition: $TOXENV != docs && $TOXENV != desc
+    condition: $TRAVIS_STAGE = deploy
   distributions: bdist_wheel

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 0.10 (TBD)
 ++++++++++
 
+* Deprecate the After All feature.
+  Travis now has `Build Stages`_, which are a better solution.
+
+.. _`Build Stages`: https://docs.travis-ci.com/user/build-stages
+
 
 0.9 (2017-11-12)
 ++++++++++++++++

--- a/docs/after.rst
+++ b/docs/after.rst
@@ -2,6 +2,22 @@
 After All
 =========
 
+.. deprecated:: 0.10
+
+.. warning::
+
+  This feature is deprecated.
+
+  Travis has added `Build Stages`_,
+  which are a better solution to this problem.
+  You will also likely want to check out `Conditions`_,
+  which make it much easier to determine
+  which jobs, stages, and builds will run.
+
+.. _`Build Stages`: https://docs.travis-ci.com/user/build-stages
+.. _`Conditions`: https://docs.travis-ci.com/user/conditional-builds-stages-jobs
+
+
 Inspired by `travis-after-all`_ and `travis_after_all`_,
 this feature allows a job to wait for other jobs to finish
 before it calls itself complete.
@@ -77,7 +93,7 @@ that corresponds to using the above ``travis:after`` section:
 This example deploys when the build is from a tag
 and the build is on Python 3.5
 and the build is using DJANGO="1.8".
-Together ``tox --travis-after`` and Tox's ``on`` conditions
+Together ``tox --travis-after`` and Travis' ``on`` conditions
 make sure that the deploy only happens after all tests pass.
 
 If any configuration item does not match,

--- a/src/tox_travis/hooks.py
+++ b/src/tox_travis/hooks.py
@@ -51,6 +51,13 @@ def tox_configure(config):
         for envconfig in config.envconfigs.values():
             envconfig.ignore_outcome = False
 
+    # after
+    if config.option.travis_after:
+        print('The after all feature has been deprecated. Check out Travis\' '
+              'build stages, which are a better solution. '
+              'See https://tox-travis.readthedocs.io/en/stable/after.html '
+              'for more details.', file=sys.stderr)
+
 
 def tox_subcommand_test_post(config):
     """Wait for this job if the configuration matches."""

--- a/tests/test_envlist.py
+++ b/tests/test_envlist.py
@@ -210,7 +210,7 @@ class TestToxEnv:
             assert self.tox_envs() == expected
 
     def test_travis_config_filename(self, tmpdir, monkeypatch):
-        """Give the correct env for CPython 2.7."""
+        """Give the correct env for manual filename."""
         with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 6,
                             ini_filename='spam.ini'):
             assert self.tox_envs(ini_filename='spam.ini') == ['py36']

--- a/tox.ini
+++ b/tox.ini
@@ -28,9 +28,6 @@ deps =
 commands =
     python setup.py check --restructuredtext --strict
 
-[travis:after]
-toxenv = py36
-
 [flake8]
 ignore = D203
 


### PR DESCRIPTION
Deprecate the After All feature in favor of Travis native build stages. Because they are native to Travis, stages are a better way to implement waiting for all the jobs to finish.

Add a deprecation warning on usage, in the changelog, and in the docs.

Use build stages in our own deployment process, and use the new conditional builds, stages, and jobs to limit when the deployment happens, and which branches are built, and to better signal that only tags should be deployed.

If merged, this will:

* Fix #69
* Close #42 as `wontfix`
* Close #43 as `wontfix`

----

@rpkilby : I know that the past couple of days have been a flurry of pull requests that I've merged without your review. They were all related to deployment, so I didn't want to hold up the release for them. This one is different, and I'll want a review before I merge it.