### PR TITLE
Skip tag check on deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,4 @@ jobs:
       user: ryanhiebert-auto
       password:
         secure: KjQrEjwmfP+jqdHNQ6bJoNjOJHHz0kirrSORat2uJTulXaUs/nuDcZqTu7gxMFaM92z3eJZzTZmxO71cDhJiBt+FQhEtL/q8wd7Fv5d5v5EIlLFNqdEyCaTthSgXQa/HJTtbzjdFIEN8qCofHu+zEWMnb1ZHgUcK7hZHMCrHcVF4kD+k1myNro+1Pp/sGIUMUOkqocz+8OI2FuEQh0txXl0MLf2UEk53EK2noD4D/fm/YDDYJbAWlNPBbCBaU/ZGfzuFivh00bx9lAg7UB6t/A3iIasRUiAJbHdxvrxxGFAeOV/t09TcTtEcwBRyPe8JzSuReCROccyFB2TLOzfkt9h7TkdC2CWrMmXpI6UogTct++r3kavdsJuAZMbSy1jrnxkxtB1CW7DOly4v4JuyewpET7CnTjkhd9zIowESwJFjxwmns63AS2okQdPTCqsbbNp53Jk5fpf6qXwMFdaHT1kU1MpwoQPT0HnwLz3xybvjgfgu3t4KfEBvc0DCp89VMjCM9xkKTlziZkwOhXqaNhu+cVqo1/eUY/HDT/7V7xiL/U6U11UOrqtxkdDofoIl4NuiT7uoVaVctm/Y4kBEkJRZCwcjRsZJ0c06SvMvxhMDBUEM5IiXS6tH6Zp08MDYlclpKFGKdzOrxP2X0rVFIZ99KLyhfRNZuZcu92tDpP8=
-      on:
-        tags: true
       distributions: bdist_wheel


### PR DESCRIPTION
Since the deploy stage already ensures that it's a tag running, it's redundant to have it on the deploy itself.