### PR TITLE
Drop support for Python 3.2 and 3.3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,6 @@
 environment:
   matrix:
     - TOXENV: py27
-    - TOXENV: py33
     - TOXENV: py34
     - TOXENV: py35
     - TOXENV: py36

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 docs/_build/
 /.coverage*
 /htmlcov/
+/.pytest_cache/
+/.vscode/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,11 @@ language: python
 python:
  - "2.6"
  - "2.7"
- - "3.2"
- - "3.3"
  - "3.4"
  - "3.5"
  - "3.6"
  - "pypy"
  - "pypy3"
- - "pypy3.3-5.2-alpha1"
- - "pypy3.3-5.5-alpha"
  - "3.7-dev"
 
 install:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -86,6 +86,6 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5, 3.6 and for PyPy, PyPy3.
+3. The pull request should work for Python 2.6, 2.7, 3.4, 3.5, 3.6 and for PyPy, PyPy3.
    Check https://travis-ci.org/ryanhiebert/tox-travis/pull_requests
    and make sure that the tests pass for all supported Python versions.

--- a/setup.py
+++ b/setup.py
@@ -69,10 +69,6 @@ setup(
         'tox': ['travis = tox_travis.hooks'],
     },
     install_requires=['tox>=2.0'],
-    extras_require={
-        ':python_version=="3.2"': ['virtualenv<14', 'pytest<3'],
-        ':platform_python_implementation=="PyPy" and python_version=="3.3"': ['virtualenv>=15.0.2'],
-    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
@@ -82,8 +78,6 @@ setup(
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tests/test_envlist.py
+++ b/tests/test_envlist.py
@@ -20,7 +20,7 @@ source =
 
 tox_ini = b"""
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy, pypy3, docs
+envlist = py26, py27, py34, pypy, pypy3, docs
 """
 
 tox_ini_override = tox_ini + b"""
@@ -203,10 +203,7 @@ class TestToxEnv:
     def test_not_travis(self, tmpdir, monkeypatch):
         """Test the results if it's not on a Travis worker."""
         with self.configure(tmpdir, monkeypatch, tox_ini):
-            expected = [
-                'py26', 'py27', 'py32', 'py33', 'py34',
-                'pypy', 'pypy3', 'docs',
-            ]
+            expected = ['py26', 'py27', 'py34', 'pypy', 'pypy3', 'docs']
             assert self.tox_envs() == expected
 
     def test_travis_config_filename(self, tmpdir, monkeypatch):
@@ -225,16 +222,6 @@ class TestToxEnv:
         with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7):
             assert self.tox_envs() == ['py27']
 
-    def test_travis_default_32(self, tmpdir, monkeypatch):
-        """Give the correct env for CPython 3.2."""
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 2):
-            assert self.tox_envs() == ['py32']
-
-    def test_travis_default_33(self, tmpdir, monkeypatch):
-        """Give the correct env for CPython 3.3."""
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 3):
-            assert self.tox_envs() == ['py33']
-
     def test_travis_default_34(self, tmpdir, monkeypatch):
         """Give the correct env for CPython 3.4."""
         with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 4):
@@ -246,8 +233,8 @@ class TestToxEnv:
             assert self.tox_envs() == ['pypy']
 
     def test_travis_default_pypy3(self, tmpdir, monkeypatch):
-        """Give the correct env for PyPy for Python 3.2."""
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'PyPy', 3, 2):
+        """Give the correct env for PyPy for Python 3.5."""
+        with self.configure(tmpdir, monkeypatch, tox_ini, 'PyPy', 3, 5):
             assert self.tox_envs() == ['pypy3']
 
     def test_travis_python_version_py27(self, tmpdir, monkeypatch):

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, py36, pypy, pypy3, docs, desc
+envlist = py26, py27, py34, py35, py36, pypy, pypy3, docs, desc
 
 [testenv]
-# mock is required to allow mock_use_standalone_module
-# Coverage doesn't work on PyPy or Python 3.2
+# Coverage doesn't work on PyPy
 deps =
     pytest
     pytest-mock
-    mock
     py{26,27,33,34,35,36}: coverage_pth
 setenv =
     COVERAGE_PROCESS_START=.coveragerc
@@ -30,11 +28,6 @@ commands =
 
 [flake8]
 ignore = D203
-
-[pytest]
-# Required to allow the use of pytest-mock on Python 3.2,
-# because unittest.mock doesn't exist on Python 3.2.
-mock_use_standalone_module = true
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
Tox upstream has completely dropped support for Python 3.2 and 3.3, thus Tox-Travis now does as well.