### PR TITLE
Add Python 3.7 support in trove classifiers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
 sudo: false
 language: python
 python:
- - "2.6"
- - "2.7"
- - "3.4"
- - "3.5"
- - "3.6"
- - "pypy"
- - "pypy3"
- - "3.7-dev"
+  - "2.6"
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "pypy"
+  - "pypy3"
 
 install:
- - pip install wheel codecov coverage
- - python setup.py bdist_wheel
- - pip install ./dist/tox_travis-*.whl
+  - pip install wheel codecov coverage
+  - python setup.py bdist_wheel
+  - pip install ./dist/tox_travis-*.whl
 script: tox --installpkg ./dist/tox_travis-*.whl
 after_success: coverage combine && codecov
 
@@ -25,20 +24,23 @@ stages:
 jobs:
   fast_finish: true
   include:
-  - python: 3.6
-    env: TOXENV=docs
-  - python: 3.6
-    env: TOXENV=desc
-  - stage: deploy
-    python: 3.6
-    install: true
-    script: true
-    after_success: true
-    deploy:
-      provider: pypi
-      user: ryanhiebert-auto
-      password:
-        secure: KjQrEjwmfP+jqdHNQ6bJoNjOJHHz0kirrSORat2uJTulXaUs/nuDcZqTu7gxMFaM92z3eJZzTZmxO71cDhJiBt+FQhEtL/q8wd7Fv5d5v5EIlLFNqdEyCaTthSgXQa/HJTtbzjdFIEN8qCofHu+zEWMnb1ZHgUcK7hZHMCrHcVF4kD+k1myNro+1Pp/sGIUMUOkqocz+8OI2FuEQh0txXl0MLf2UEk53EK2noD4D/fm/YDDYJbAWlNPBbCBaU/ZGfzuFivh00bx9lAg7UB6t/A3iIasRUiAJbHdxvrxxGFAeOV/t09TcTtEcwBRyPe8JzSuReCROccyFB2TLOzfkt9h7TkdC2CWrMmXpI6UogTct++r3kavdsJuAZMbSy1jrnxkxtB1CW7DOly4v4JuyewpET7CnTjkhd9zIowESwJFjxwmns63AS2okQdPTCqsbbNp53Jk5fpf6qXwMFdaHT1kU1MpwoQPT0HnwLz3xybvjgfgu3t4KfEBvc0DCp89VMjCM9xkKTlziZkwOhXqaNhu+cVqo1/eUY/HDT/7V7xiL/U6U11UOrqtxkdDofoIl4NuiT7uoVaVctm/Y4kBEkJRZCwcjRsZJ0c06SvMvxhMDBUEM5IiXS6tH6Zp08MDYlclpKFGKdzOrxP2X0rVFIZ99KLyhfRNZuZcu92tDpP8=
-      distributions: sdist bdist_wheel
-      on:
-        all_branches: true
+    - python: 3.7
+      dist: xenial
+      sudo: true
+    - python: 3.6
+      env: TOXENV=docs
+    - python: 3.6
+      env: TOXENV=desc
+    - stage: deploy
+      python: 3.6
+      install: true
+      script: true
+      after_success: true
+      deploy:
+        provider: pypi
+        user: ryanhiebert-auto
+        password:
+          secure: KjQrEjwmfP+jqdHNQ6bJoNjOJHHz0kirrSORat2uJTulXaUs/nuDcZqTu7gxMFaM92z3eJZzTZmxO71cDhJiBt+FQhEtL/q8wd7Fv5d5v5EIlLFNqdEyCaTthSgXQa/HJTtbzjdFIEN8qCofHu+zEWMnb1ZHgUcK7hZHMCrHcVF4kD+k1myNro+1Pp/sGIUMUOkqocz+8OI2FuEQh0txXl0MLf2UEk53EK2noD4D/fm/YDDYJbAWlNPBbCBaU/ZGfzuFivh00bx9lAg7UB6t/A3iIasRUiAJbHdxvrxxGFAeOV/t09TcTtEcwBRyPe8JzSuReCROccyFB2TLOzfkt9h7TkdC2CWrMmXpI6UogTct++r3kavdsJuAZMbSy1jrnxkxtB1CW7DOly4v4JuyewpET7CnTjkhd9zIowESwJFjxwmns63AS2okQdPTCqsbbNp53Jk5fpf6qXwMFdaHT1kU1MpwoQPT0HnwLz3xybvjgfgu3t4KfEBvc0DCp89VMjCM9xkKTlziZkwOhXqaNhu+cVqo1/eUY/HDT/7V7xiL/U6U11UOrqtxkdDofoIl4NuiT7uoVaVctm/Y4kBEkJRZCwcjRsZJ0c06SvMvxhMDBUEM5IiXS6tH6Zp08MDYlclpKFGKdzOrxP2X0rVFIZ99KLyhfRNZuZcu92tDpP8=
+        distributions: sdist bdist_wheel
+        on:
+          all_branches: true

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,3 +1,8 @@
+0.13
+++++
+
+* Add Python 3.7 support in trove classifiers.
+
 0.12 (2019-03-14)
 +++++++++++++++++
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -86,6 +86,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.4, 3.5, 3.6 and for PyPy, PyPy3.
+3. The pull request should work for Python 2.6, 2.7, 3.4, 3.5, 3.6, 3.7
+   and for PyPy, PyPy3.
    Check https://travis-ci.org/ryanhiebert/tox-travis/pull_requests
    and make sure that the tests pass for all supported Python versions.

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Testing',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py26, py27, py34, py35, py36, pypy, pypy3, docs, desc
+envlist = py26, py27, py34, py35, py36, py37, pypy, pypy3, docs, desc
 
 [testenv]
 # Coverage doesn't work on PyPy
 deps =
     pytest
     pytest-mock
-    py{26,27,33,34,35,36}: coverage_pth
+    py{26,27,33,34,35,36,37}: coverage_pth
 setenv =
     COVERAGE_PROCESS_START=.coveragerc
 commands = {posargs:py.test}


### PR DESCRIPTION
Replaces 3.7-dev travis environment with release 3.7.

And uses standard two space indents throughout .travis.yml

Closes https://github.com/tox-dev/tox-travis/issues/124