### PR TITLE
Docs: Remove sudo from examples, fix typos, update org name

### DIFF
--- a/docs/after.rst
+++ b/docs/after.rst
@@ -67,7 +67,6 @@ that corresponds to using the above ``travis:after`` section:
 
 .. code-block:: yaml
 
-    sudo: false
     language: python
     python:
       - "2.6"

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -12,7 +12,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/ryanhiebert/tox-travis/issues. If you are
+Report bugs at https://github.com/tox-dev/tox-travis/issues. If you are
 reporting a bug, please include:
 
 * Any details about your local setup that might be helpful in troubleshooting.
@@ -41,7 +41,7 @@ Submit Feedback
 ~~~~~~~~~~~~~~~
 
 The best way to send feedback is to file an issue at
-https://github.com/ryanhiebert/tox-travis/issues. If you are proposing a feature:
+https://github.com/tox-dev/tox-travis/issues. If you are proposing a feature:
 
 * Explain in detail how it would work.
 * Keep the scope as narrow as possible, to make it easier to implement.
@@ -88,5 +88,5 @@ Before you submit a pull request, check that it meets these guidelines:
    feature to the list in README.rst.
 3. The pull request should work for Python 2.6, 2.7, 3.4, 3.5, 3.6, 3.7
    and for PyPy, PyPy3.
-   Check https://travis-ci.org/ryanhiebert/tox-travis/pull_requests
+   Check https://travis-ci.org/tox-dev/tox-travis/pull_requests
    and make sure that the tests pass for all supported Python versions.

--- a/docs/envlist.rst
+++ b/docs/envlist.rst
@@ -50,7 +50,7 @@ This would run the Python 2.7 variants under 2.7,
 and the Python 3.4 variants and the ``docs`` env under 3.4.
 
 Note that Travis won't run all the envs simultaneously,
-because it's build matrix is only aware of the Python versions.
+because its build matrix is only aware of the Python versions.
 Only one Travis build will be run per Python version,
 unless other settings are specified in the Travis build matrix.
 

--- a/docs/envlist.rst
+++ b/docs/envlist.rst
@@ -15,7 +15,6 @@ Configure the Python versions to test with in ``.travis.yml``:
 
 .. code-block:: yaml
 
-    sudo: false
     language: python
     python:
       - "2.7"
@@ -61,7 +60,6 @@ For example, see the following ``.travis.yml`` and ``tox.ini``:
 
 .. code-block:: yaml
 
-    sudo: false
     language: python
     python:
       - "2.7"

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ if _markerlib and sys.version_info[0] == 3:
 
     _markerlib.default_environment = default_environment
 
-# Avoid the very buggy pkg_resources.parser, which doesnt consistently
+# Avoid the very buggy pkg_resources.parser, which doesn't consistently
 # recognise the markers needed by this setup.py
 # Change this to setuptools 20.10.0 to support all markers.
 if pkg_resources:

--- a/src/tox_travis/hacks.py
+++ b/src/tox_travis/hacks.py
@@ -9,7 +9,7 @@ except ImportError:
 def pypy_version_monkeypatch():
     """Patch Tox to work with non-default PyPy 3 versions."""
     # Travis virtualenv do not provide `pypy3`, which tox tries to execute.
-    # This doesnt affect Travis python version `pypy3`, as the pyenv pypy3
+    # This doesn't affect Travis python version `pypy3`, as the pyenv pypy3
     # is in the PATH.
     # https://github.com/travis-ci/travis-ci/issues/6304
     # Force use of the virtualenv `python`.

--- a/tests/test_after.py
+++ b/tests/test_after.py
@@ -194,7 +194,7 @@ class TestAfter:
                         'committed_at': '2016-07-01T21:17:38Z',
                         'committer_email': 'ryan@ryanhiebert.com',
                         'committer_name': 'Ryan Hiebert',
-                        'compare_url': 'https://github.com/ryanhiebert/tox-travis/pull/21',  # noqa
+                        'compare_url': 'https://github.com/tox-dev/tox-travis/pull/21',
                         'id': 40173062,
                         'message': 'Add languages to the mix',
                         'sha': 'f5ba1abff4fa27ea48bf3eac3a924477aea13dd8'},
@@ -293,7 +293,7 @@ class TestAfter:
                         'committed_at': '2016-07-01T21:16:05Z',
                         'committer_email': 'ryan@ryanhiebert.com',
                         'committer_name': 'Ryan Hiebert',
-                        'compare_url': 'https://github.com/ryanhiebert/tox-travis/pull/21',  # noqa
+                        'compare_url': 'https://github.com/tox-dev/tox-travis/pull/21',
                         'id': 40172931,
                         'message': 'Add languages to the mix',
                         'sha': '06e89f20adb11423a538f29d8144abcbe508d575'},


### PR DESCRIPTION
* Remove `sudo: false` from examples, it's no longer needed: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration
* Fix typos
* Update repo org name