### PR TITLE
README: sudo no longer needed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,6 @@ and install ``tox-travis`` with pip:
 
 .. code-block:: yaml
 
-    sudo: false
     language: python
     python:
       - "2.7"


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

I missed this in https://github.com/tox-dev/tox-travis/pull/135.