### PR TITLE
Drop support for EOL Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
-sudo: false
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"

--- a/docs/after.rst
+++ b/docs/after.rst
@@ -69,7 +69,7 @@ that corresponds to using the above ``travis:after`` section:
 
     language: python
     python:
-      - "2.6"
+      - "2.7"
       - "3.5"
     env:
       global:

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -86,7 +86,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.6, 2.7, 3.4, 3.5, 3.6, 3.7
+3. The pull request should work for Python 2.7 and 3.4+
    and for PyPy, PyPy3.
    Check https://travis-ci.org/tox-dev/tox-travis/pull_requests
    and make sure that the tests pass for all supported Python versions.

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ class Python3MarkerDict(dict):
         return self[i]
 
 
-if _markerlib and sys.version_info[0] == 3:
+if _markerlib and sys.version_info[0] >= 3:
     env = _markerlib.markers._VARS
     for key in list(env):
         new_key = key.replace('.', '_')

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         'tox': ['travis = tox_travis.hooks'],
     },
     install_requires=['tox>=2.0'],
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/tests/test_envlist.py
+++ b/tests/test_envlist.py
@@ -21,7 +21,7 @@ source =
 
 tox_ini = b"""
 [tox]
-envlist = py26, py27, py34, pypy, pypy3, docs
+envlist = py27, py34, pypy, pypy3, docs
 """
 
 tox_ini_override = tox_ini + b"""
@@ -204,7 +204,7 @@ class TestToxEnv:
     def test_not_travis(self, tmpdir, monkeypatch):
         """Test the results if it's not on a Travis worker."""
         with self.configure(tmpdir, monkeypatch, tox_ini):
-            expected = ['py26', 'py27', 'py34', 'pypy', 'pypy3', 'docs']
+            expected = ['py27', 'py34', 'pypy', 'pypy3', 'docs']
             assert self.tox_envs() == expected
 
     def test_travis_config_filename(self, tmpdir, monkeypatch):
@@ -212,11 +212,6 @@ class TestToxEnv:
         with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 6,
                             ini_filename='spam.ini'):
             assert self.tox_envs(ini_filename='spam.ini') == ['py36']
-
-    def test_travis_default_26(self, tmpdir, monkeypatch):
-        """Give the correct env for CPython 2.6."""
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 6):
-            assert self.tox_envs() == ['py26']
 
     def test_travis_default_27(self, tmpdir, monkeypatch):
         """Give the correct env for CPython 2.7."""

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py26, py27, py34, py35, py36, py37, pypy, pypy3, docs, desc
+envlist = py27, py34, py35, py36, py37, pypy, pypy3, docs, desc
 
 [testenv]
 # Coverage doesn't work on PyPy
 deps =
     pytest
     pytest-mock
-    py{26,27,33,34,35,36,37}: coverage_pth
+    py{27,33,34,35,36,37}: coverage_pth
 setenv =
     COVERAGE_PROCESS_START=.coveragerc
 commands = {posargs:py.test}


### PR DESCRIPTION
Python 2.6 is failing the build ([example](https://github.com/tox-dev/tox-travis/pull/138)). It's EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.6 | 2008-10-01 | 2013-10-29
2.7 | 2010-07-03 | 2020-01-01
3.0 | 2008-12-03 | 2009-06-27
3.1 | 2009-06-27 | 2012-04-09
3.2 | 2011-02-20 | 2016-02-27
3.3 | 2012-09-29 | 2017-09-29
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

It's also little used. Here's the pip installs for tox-travis from PyPI for August 2019:

| category | percent | downloads |
|----------|--------:|----------:|
| 3.6      |  34.85% |    40,979 |
| 3.7      |  20.44% |    24,028 |
| 2.7      |  18.72% |    22,012 |
| 3.5      |  17.64% |    20,737 |
| 3.4      |   6.34% |     7,454 |
| 3.8      |   1.87% |     2,197 |
| null     |   0.08% |        96 |
| 3.3      |   0.03% |        41 |
| 2.6      |   0.03% |        34 |
| 3.2      |   0.00% |         2 |
| Total    |         |   117,580 |

Date range: 2019-08-01 - 2019-08-31

Source: `pip install -U pypistats && pypistats python_minor tox-travis --last-month`
