### PR TITLE
Update tests and docs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,6 +4,7 @@ environment:
     - TOXENV: py34
     - TOXENV: py35
     - TOXENV: py36
+    - TOXENV: py37
 install:
   - C:\Python37\python -m pip install -U pip virtualenv setuptools wheel six
   - C:\Python37\python -m pip install -U tox

--- a/README.rst
+++ b/README.rst
@@ -33,12 +33,12 @@ and install ``tox-travis`` with pip:
 
     language: python
     python:
-      - "2.7"
-      - "3.4"
+      - "3.6"
+      - "3.7"
     install: pip install tox-travis
     script: tox
 
-tox will only run the ``py27`` or ``py34`` env
+tox will only run the ``py36`` or ``py37`` env
 (or envs that have a factor that matches)
 as appropriate for the version of Python
 that is being run by each Travis job.

--- a/docs/envlist.rst
+++ b/docs/envlist.rst
@@ -17,16 +17,16 @@ Configure the Python versions to test with in ``.travis.yml``:
 
     language: python
     python:
-      - "2.7"
-      - "3.4"
+      - "3.6"
+      - "3.7"
     install: pip install tox-travis
     script: tox
 
 And it will run the appropriate testenvs,
 which by default are any declared env with
-``py27`` or ``py34`` as factors of the name.
+``py36`` or ``py37`` as factors of the name.
 If no environments match a given factor,
-the ``py27`` or ``py34`` envs are used as a fallback.
+the ``py36`` or ``py37`` envs are used as a fallback.
 
 
 Advanced Configuration
@@ -39,15 +39,15 @@ to run under which versions of Python:
 .. code-block:: ini
 
     [tox]
-    envlist = py{27,34}-django{17,18}, docs
+    envlist = py{36,37}-django{21,22}, docs
 
     [travis]
     python =
-      2.7: py27
-      3.4: py34, docs
+      3.6: py36
+      3.7: py37, docs
 
-This would run the Python 2.7 variants under 2.7,
-and the Python 3.4 variants and the ``docs`` env under 3.4.
+This would run the Python 3.6 variants under 3.6,
+and the Python 3.7 variants and the ``docs`` env under 3.7.
 
 Note that Travis won't run all the envs simultaneously,
 because its build matrix is only aware of the Python versions.
@@ -62,11 +62,11 @@ For example, see the following ``.travis.yml`` and ``tox.ini``:
 
     language: python
     python:
-      - "2.7"
-      - "3.4"
+      - "3.6"
+      - "3.7"
     env:
-      - DJANGO="1.7"
-      - DJANGO="1.8"
+      - DJANGO="2.1"
+      - DJANGO="2.2"
     matrix:
       include:
         - os: osx
@@ -77,53 +77,53 @@ For example, see the following ``.travis.yml`` and ``tox.ini``:
 .. code-block:: ini
 
     [tox]
-    envlist = py{27,34}-django{17,18}, docs
+    envlist = py{36,37}-django{21,22}, docs
 
     [travis]
     os =
-      linux: py{27,34}-django{17,18}, docs
-      osx: py{27,34}-django{17,18}
+      linux: py{36,37}-django{21,22}, docs
+      osx: py{36,37}-django{21,22}
     python =
-      3.4: py34, docs
+      3.7: py37, docs
 
     [travis:env]
     DJANGO =
-      1.7: django17
-      1.8: django18, docs
+      2.1: django21
+      2.2: django22, docs
 
 Travis will run 5 different jobs,
 which will each run jobs as specified by the factors given.
 
-* os: linux (default), language: python, python: 2.7, env: DJANGO=1.7
+* os: linux (default), language: python, python: 3.6, env: DJANGO=2.1
 
-  This will run the env ``py27-django17``,
-  because ``py27`` is the default,
-  and ``django17`` is specified.
+  This will run the env ``py36-django21``,
+  because ``py36`` is the default,
+  and ``django21`` is specified.
 
-* os: linux (default), language: python, python: 3.4, env: DJANGO=1.7
+* os: linux (default), language: python, python: 3.7, env: DJANGO=2.2
 
-  This will run the env ``py34-django17``,
+  This will run the env ``py37-django22``,
   but not ``docs``,
-  because ``docs`` is not included in the DJANGO 1.7 configuration.
+  because ``docs`` is not included in the DJANGO 2.2 configuration.
 
-* os: linux (default), language: python, python: 2.7, env: DJANGO=1.8
+* os: linux (default), language: python, python: 3.6, env: DJANGO=2.1
 
-  This will run the env ``py27-django18``,
-  because ``py27`` is the default.
+  This will run the env ``py36-django21``,
+  because ``py36`` is the default.
   ``docs`` is not run,
-  because Python 2.7 doesn't include ``docs``
+  because Python 3.6 doesn't include ``docs``
   in the defaults that are not overridden.
 
-* os: linux (default), language: python, python: 3.4, env: DJANGO=1.8
+* os: linux (default), language: python, python: 3.7, env: DJANGO=2.2
 
-  This will run the envs ``py34-django18`` and ``docs``,
+  This will run the envs ``py37-django22`` and ``docs``,
   because all specified factors match,
   and ``docs`` is present in all related factors.
 
 * os: osx, language: generic
 
-  This will run envs ``py27-django17``, ``py34-django17``,
-  ``py27-django18``, and ``py34-django18``,
+  This will run envs ``py36-django21``, ``py37-django21``,
+  ``py36-django22``, and ``py37-django22``,
   because the ``os`` factor is present,
   and limits it to just those envs.
 

--- a/tests/test_envlist.py
+++ b/tests/test_envlist.py
@@ -21,86 +21,86 @@ source =
 
 tox_ini = b"""
 [tox]
-envlist = py27, py34, pypy, pypy3, docs
+envlist = py36, py37, pypy, pypy3, docs
 """
 
 tox_ini_override = tox_ini + b"""
 [tox:travis]
-2.7 = py27, docs
+3.6 = py36, docs
 """
 
 tox_ini_factors = b"""
 [tox]
-envlist = py34, py34-docs, py34-django, dontmatch-1
+envlist = py37, py37-docs, py37-django, dontmatch-1
 """
 
 tox_ini_factors_override = tox_ini_factors + b"""
 [tox:travis]
-2.7 = py27-django
+3.6 = py36-django
 """
 
 tox_ini_factors_override_nonenvlist = tox_ini_factors + b"""
 [tox:travis]
-3.4 = py34, extra
+3.7 = py37, extra
 
 [testenv:extra-coveralls]
-basepython=python3.4
+basepython=python3.7
 
 [testenv:extra-flake8]
-basepython=python3.4
+basepython=python3.7
 
 [testenv:dontmatch-2]
-basepython=python3.4
+basepython=python3.7
 """
 
 tox_ini_django_factors = b"""
 [tox]
-envlist = py{27,34}-django, other
+envlist = py{36,37}-django, other
 
 [tox:travis]
-2.7 = django
-3.4 = other
+3.6 = django
+3.7 = other
 """
 
 tox_ini_travis_factors = b"""
 [tox]
-envlist = py{27,34,35}, docs
+envlist = py{35,36,37}, docs
 
 [travis]
 language =
-    generic: py{27,35}, docs
+    generic: py{36,37}, docs
 python =
-    2.7: py27, docs
+    3.6: py36, docs
 os =
-    osx: py{27,35}, docs
+    osx: py{36,37}, docs
 """
 
 tox_ini_travis_env = b"""
 [tox]
-envlist = py{27,35}-django{19,110}
+envlist = py{36,37}-django{21,22}
 
 [travis:env]
 DJANGO =
-    1.9: django19
-    1.10: django110
+    2.1: django21
+    2.2: django22
 """
 
 tox_ini_legacy_warning = b"""
 [tox]
-envlist = py{27,35}-django{19,110}
+envlist = py{36,37}-django{21,22}
 
 [tox:travis]
-3.4 = py34, extra
+3.7 = py37, extra
 
 [travis:env]
 DJANGO =
-    1.9: django19
-    1.10: django110
+    2.1: django21
+    2.2: django22
 """
 
 tox_ini_ignore_outcome = b"""
 [tox]
-envlist = py{27,34,35}
+envlist = py{35,36,37}
 
 [testenv]
 ignore_outcome = True
@@ -204,7 +204,7 @@ class TestToxEnv:
     def test_not_travis(self, tmpdir, monkeypatch):
         """Test the results if it's not on a Travis worker."""
         with self.configure(tmpdir, monkeypatch, tox_ini):
-            expected = ['py27', 'py34', 'pypy', 'pypy3', 'docs']
+            expected = ['py36', 'py37', 'pypy', 'pypy3', 'docs']
             assert self.tox_envs() == expected
 
     def test_travis_config_filename(self, tmpdir, monkeypatch):
@@ -213,15 +213,15 @@ class TestToxEnv:
                             ini_filename='spam.ini'):
             assert self.tox_envs(ini_filename='spam.ini') == ['py36']
 
-    def test_travis_default_27(self, tmpdir, monkeypatch):
+    def test_travis_default_36(self, tmpdir, monkeypatch):
         """Give the correct env for CPython 2.7."""
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7):
-            assert self.tox_envs() == ['py27']
+        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 6):
+            assert self.tox_envs() == ['py36']
 
-    def test_travis_default_34(self, tmpdir, monkeypatch):
-        """Give the correct env for CPython 3.4."""
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 4):
-            assert self.tox_envs() == ['py34']
+    def test_travis_default_37(self, tmpdir, monkeypatch):
+        """Give the correct env for CPython 3.7."""
+        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 7):
+            assert self.tox_envs() == ['py37']
 
     def test_travis_default_pypy(self, tmpdir, monkeypatch):
         """Give the correct env for PyPy for Python 2.7."""
@@ -233,12 +233,12 @@ class TestToxEnv:
         with self.configure(tmpdir, monkeypatch, tox_ini, 'PyPy', 3, 5):
             assert self.tox_envs() == ['pypy3']
 
-    def test_travis_python_version_py27(self, tmpdir, monkeypatch):
+    def test_travis_python_version_py36(self, tmpdir, monkeypatch):
         """Give the correct env when python version is given by Travis."""
         with self.configure(
-            tmpdir, monkeypatch, tox_ini, travis_version='2.7'
+            tmpdir, monkeypatch, tox_ini, travis_version='3.6'
         ):
-            assert self.tox_envs() == ['py27']
+            assert self.tox_envs() == ['py36']
 
     def test_travis_python_version_py35(self, tmpdir, monkeypatch):
         """Give the correct env when python version is given by Travis."""
@@ -272,22 +272,22 @@ class TestToxEnv:
         support for the ``python`` factor.
         """
         with self.configure(
-            tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7, '3.5'
+            tmpdir, monkeypatch, tox_ini, 'CPython', 3, 6, '3.6'
         ):
-            assert self.tox_envs() == ['py35']
+            assert self.tox_envs() == ['py36']
 
     def test_travis_nightly(self, tmpdir, monkeypatch):
         """When nightly is specified, it should use sys.version_info."""
         with self.configure(
-            tmpdir, monkeypatch, tox_ini, 'CPython', 3, 5, 'nightly'
+            tmpdir, monkeypatch, tox_ini, 'CPython', 3, 6, 'nightly'
         ):
-            assert self.tox_envs() == ['py35']
+            assert self.tox_envs() == ['py36']
 
     def test_travis_override(self, tmpdir, monkeypatch):
         """Test when the setting is overridden for a particular Python."""
         tox_ini = tox_ini_override
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7):
-            assert self.tox_envs() == ['py27', 'docs']
+        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 6):
+            assert self.tox_envs() == ['py36', 'docs']
 
     # XFAIL because of changes to tox -l to make it show declared envs
     # rather than the envs that will actually run, which is what we
@@ -298,77 +298,77 @@ class TestToxEnv:
     @pytest.mark.xfail
     def test_respect_overridden_toxenv(self, tmpdir, monkeypatch):
         """Ensure that TOXENV if given is not changed."""
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7):
+        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 6):
             monkeypatch.setenv('TOXENV', 'py32')
             assert self.tox_envs() == ['py32']
 
     def test_keep_if_no_match(self, tmpdir, monkeypatch):
         """It should keep the desired env if no declared env matches."""
         tox_ini = tox_ini_factors
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7):
-            assert self.tox_envs() == ['py27']
+        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 6):
+            assert self.tox_envs() == ['py36']
 
     def test_default_tox_ini_overrides(self, tmpdir, monkeypatch):
         """Keep the overridden envlist verbatim when no envlist is declared."""
         tox_ini = tox_ini_factors_override
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7):
-            assert self.tox_envs() == ['py27-django']
+        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 6):
+            assert self.tox_envs() == ['py36-django']
 
     def test_factors(self, tmpdir, monkeypatch):
         """Test that it will match envs by factors."""
         tox_ini = tox_ini_factors
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 4):
-            assert self.tox_envs() == ['py34', 'py34-docs', 'py34-django']
+        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 7):
+            assert self.tox_envs() == ['py37', 'py37-docs', 'py37-django']
 
     def test_match_and_keep(self, tmpdir, monkeypatch):
         """Match factors for envs declared outside of envlist."""
         tox_ini = tox_ini_factors_override_nonenvlist
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 4):
-            assert self.tox_envs() == ['py34', 'py34-docs', 'py34-django',
+        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 7):
+            assert self.tox_envs() == ['py37', 'py37-docs', 'py37-django',
                                        'extra-coveralls', 'extra-flake8']
 
     def test_django_factors(self, tmpdir, monkeypatch):
         """A non-default factor completely overrides the default factor."""
         tox_ini = tox_ini_django_factors
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 2, 7):
-            assert self.tox_envs() == ['py27-django', 'py34-django']
+        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 6):
+            assert self.tox_envs() == ['py36-django', 'py37-django']
 
     def test_non_python_factor(self, tmpdir, monkeypatch):
         """A non-default factor completely overrides the default factor."""
         tox_ini = tox_ini_django_factors
-        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 4):
+        with self.configure(tmpdir, monkeypatch, tox_ini, 'CPython', 3, 7):
             assert self.tox_envs() == ['other']
 
-    def test_travis_factors_py27(self, tmpdir, monkeypatch):
+    def test_travis_factors_py36(self, tmpdir, monkeypatch):
         """Test python factor given in the new travis section."""
         tox_ini = tox_ini_travis_factors
         with self.configure(
-            tmpdir, monkeypatch, tox_ini, travis_version='2.7'
+            tmpdir, monkeypatch, tox_ini, travis_version='3.6'
         ):
-            assert self.tox_envs() == ['py27', 'docs']
+            assert self.tox_envs() == ['py36', 'docs']
 
-    def test_travis_factors_py35(self, tmpdir, monkeypatch):
+    def test_travis_factors_py37(self, tmpdir, monkeypatch):
         """Test python factor given in the new travis section."""
         tox_ini = tox_ini_travis_factors
         with self.configure(
-            tmpdir, monkeypatch, tox_ini, travis_version='3.5'
+            tmpdir, monkeypatch, tox_ini, travis_version='3.7'
         ):
-            assert self.tox_envs() == ['py35']
+            assert self.tox_envs() == ['py37']
 
     def test_travis_factors_osx(self, tmpdir, monkeypatch):
         """Test os factor given in the new travis section."""
         tox_ini = tox_ini_travis_factors
         with self.configure(tmpdir, monkeypatch, tox_ini, travis_os='osx'):
-            assert self.tox_envs() == ['py27', 'py35', 'docs']
+            assert self.tox_envs() == ['py36', 'py37', 'docs']
 
-    def test_travis_factors_py27_osx(self, tmpdir, monkeypatch):
+    def test_travis_factors_py36_osx(self, tmpdir, monkeypatch):
         """Test os and python factors given in the new travis section."""
         tox_ini = tox_ini_travis_factors
         with self.configure(
             tmpdir, monkeypatch, tox_ini,
-            travis_version='2.7', travis_os='osx'
+            travis_version='3.6', travis_os='osx'
         ):
-            assert self.tox_envs() == ['py27', 'docs']
+            assert self.tox_envs() == ['py36', 'docs']
 
     def test_travis_factors_language(self, tmpdir, monkeypatch):
         """Test language factor given in the new travis section."""
@@ -376,39 +376,39 @@ class TestToxEnv:
         with self.configure(
             tmpdir, monkeypatch, tox_ini, travis_language='generic'
         ):
-            assert self.tox_envs() == ['py27', 'py35', 'docs']
+            assert self.tox_envs() == ['py36', 'py37', 'docs']
 
-    def test_travis_env_py27(self, tmpdir, monkeypatch):
+    def test_travis_env_py36(self, tmpdir, monkeypatch):
         """Test that env factors are ignored if not fulfilled."""
         tox_ini = tox_ini_travis_env
         with self.configure(
-            tmpdir, monkeypatch, tox_ini, travis_version='2.7'
+            tmpdir, monkeypatch, tox_ini, travis_version='3.6'
         ):
-            assert self.tox_envs() == ['py27-django19', 'py27-django110']
+            assert self.tox_envs() == ['py36-django21', 'py36-django22']
 
-    def test_travis_env_py27_dj19(self, tmpdir, monkeypatch):
+    def test_travis_env_py36_dj21(self, tmpdir, monkeypatch):
         """Test that env factors are used if they match."""
         tox_ini = tox_ini_travis_env
         with self.configure(
             tmpdir, monkeypatch, tox_ini,
-            travis_version='2.7', env={'DJANGO': '1.9'}
+            travis_version='3.6', env={'DJANGO': '2.1'}
         ):
-            assert self.tox_envs() == ['py27-django19']
+            assert self.tox_envs() == ['py36-django21']
 
-    def test_travis_env_py35_dj110(self, tmpdir, monkeypatch):
+    def test_travis_env_py37_dj22(self, tmpdir, monkeypatch):
         """Test that env factors are used if they match."""
         tox_ini = tox_ini_travis_env
         with self.configure(
             tmpdir, monkeypatch, tox_ini,
-            travis_version='3.5', env={'DJANGO': '1.10'}
+            travis_version='3.7', env={'DJANGO': '2.2'}
         ):
-            assert self.tox_envs() == ['py35-django110']
+            assert self.tox_envs() == ['py37-django22']
 
     def test_legacy_warning(self, tmpdir, monkeypatch):
         """Using the legacy tox:travis section prints a warning on stderr."""
         tox_ini = tox_ini_legacy_warning
         with self.configure(
-            tmpdir, monkeypatch, tox_ini, travis_version='2.7'
+            tmpdir, monkeypatch, tox_ini, travis_version='3.6'
         ):
             _, _, stderr = self.tox_envs_raw()
             assert (
@@ -419,34 +419,34 @@ class TestToxEnv:
         """Test ignore_outcome without setting obey_outcomes."""
         tox_ini = tox_ini_ignore_outcome
         with self.configure(
-            tmpdir, monkeypatch, tox_ini, travis_version='3.4'
+            tmpdir, monkeypatch, tox_ini, travis_version='3.7'
         ):
             config = self.tox_config()
-            assert config["testenv:py34"]["ignore_outcome"] == "True"
+            assert config["testenv:py37"]["ignore_outcome"] == "True"
 
     def test_travis_ignore_outcome_unignore_outcomes(self, tmpdir,
                                                      monkeypatch):
         """Test ignore_outcome setting unignore_outcomes = False."""
         tox_ini = tox_ini_ignore_outcome_unignore_outcomes
         with self.configure(
-            tmpdir, monkeypatch, tox_ini, travis_version='3.4'
+            tmpdir, monkeypatch, tox_ini, travis_version='3.7'
         ):
             config = self.tox_config()
-            assert config["testenv:py34"]["ignore_outcome"] == "False"
+            assert config["testenv:py37"]["ignore_outcome"] == "False"
 
     def test_travis_ignore_outcome_not_unignore_outcomes(self, tmpdir,
                                                          monkeypatch):
         """Test ignore_outcome setting unignore_outcomes = False (default)."""
         tox_ini = tox_ini_ignore_outcome_not_unignore_outcomes
         with self.configure(
-            tmpdir, monkeypatch, tox_ini, travis_version='3.4'
+            tmpdir, monkeypatch, tox_ini, travis_version='3.7'
         ):
             config = self.tox_config()
-            assert config["testenv:py34"]["ignore_outcome"] == "True"
+            assert config["testenv:py37"]["ignore_outcome"] == "True"
 
     def test_local_ignore_outcome_unignore_outcomes(self, tmpdir, monkeypatch):
         """Test ignore_outcome unchanged when testing locally."""
         tox_ini = tox_ini_ignore_outcome_unignore_outcomes
         with self.configure(tmpdir, monkeypatch, tox_ini):
             config = self.tox_config()
-            assert config["testenv:py34"]["ignore_outcome"] == "True"
+            assert config["testenv:py37"]["ignore_outcome"] == "True"

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, py38, pypy, pypy3, docs, desc
+envlist = py{27,34,35,36,37,38,py,py3}, docs, desc
 
 [testenv]
 # Coverage doesn't work on PyPy
 deps =
     pytest
     pytest-mock
-    py{27,33,34,35,36,37,38}: coverage_pth
+    py{27,34,35,36,37,38}: coverage_pth
 setenv =
     COVERAGE_PROCESS_START=.coveragerc
 commands = {posargs:py.test}


### PR DESCRIPTION
As Python 3.4 is end of life since 2019-03-18
https://www.python.org/downloads/release/python-3410/

Remove compat :
- update setup.py
- update docs
- update tox / travis / appveyor
- update tests with real examples