### PR TITLE
Do not use `sudo: true` any more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ jobs:
   fast_finish: true
   include:
     - python: 3.8
-      sudo: true
 
     - python: 3.8
       env: TOXENV=docs


### PR DESCRIPTION
It is deprecated:
https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration